### PR TITLE
pkcs12: include "friendly name" for 389ds

### DIFF
--- a/caman
+++ b/caman
@@ -352,6 +352,7 @@ function command_sign_host {
             -in "$CERTDIR/$HOST.crt.pem" \
             -out "$CERTDIR/$HOST.p12" \
             -passout "file:$CERTDIR/password" \
+            -name "Server-Cert" \
             || exit 1
         chmod 400 "$CERTDIR/$HOST.p12" || exit 1
 
@@ -385,6 +386,7 @@ function command_sign_host {
                 -certfile "$CADIR/ca-chain.crt.pem" \
                 -out "$CERTDIR/$HOST.chained.p12" \
                 -passout "file:$CERTDIR/password" \
+                -name "Server-Cert" \
                 || exit 1
             chmod 400 "$CERTDIR/$HOST.chained.p12" || exit 1
         fi


### PR DESCRIPTION
389ds seems to need a "friendly name" in the .p12, respectively when imported to the NSS database.
See for example https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-security-ldap.html